### PR TITLE
Convert address values to string before handing to address verification.

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -9,8 +9,8 @@ Spree::Address.class_eval do
 
     # Grab out the fields we need and wrap up in object
     address = SmartyStreets::StreetAddressRequest.new \
-      street: address1, street2: address2, city: city,
-      state: state_text, zipcode: zipcode, addressee: company
+      street: address1.to_s, street2: address2.to_s, city: city.to_s,
+      state: state_text.to_s, zipcode: zipcode.to_s, addressee: company.to_s
 
     begin
       address = SmartyStreets::StreetAddressApi.call address

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -6,7 +6,7 @@ describe 'Spree::Address extended to validate address' do
   # Real address in US
   let(:valid_address) do
     Spree::Address.new address1: '45 Main Street', address2: 'Suite 850',
-      city: 'Brooklyn', state: ny, zipcode: '11201', country: ny.country
+      city: 'Brooklyn', state: ny, zipcode: 11201, country: ny.country
   end
 
   # Fake address that looks real


### PR DESCRIPTION
The address verification gem is picky on the input types. They must be strings.
In case someone does zipcode: 30141, this will automatically ensure a string
is given to the address verification gem.
