### PR TITLE
Address cleanup

### DIFF
--- a/app/assets/javascripts/address-verification-overrides.js.coffee
+++ b/app/assets/javascripts/address-verification-overrides.js.coffee
@@ -3,9 +3,11 @@ $ = jQuery
 old_update_state = update_state
 update_state = (region, done)->
   old_update_state region, done
-  delay = -> $('span#' + region + 'state select.select2').select2 'destroy'
-  setTimeout delay 500
+  if $.fn.select2?
+    delay = -> $('span#' + region + 'state select.select2').select2 'destroy'
+    setTimeout delay 500
 
 $ ->
+  return unless $.fn.select2?
   for region in ['b', 's']
     $("span##{region}state select.select2").select2('destroy').addClass 'form-control'

--- a/app/assets/javascripts/address-verification-overrides.js.coffee
+++ b/app/assets/javascripts/address-verification-overrides.js.coffee
@@ -1,0 +1,11 @@
+$ = jQuery
+
+old_update_state = update_state
+update_state = (region, done)->
+  old_update_state region, done
+  delay = -> $('span#' + region + 'state select.select2').select2 'destroy'
+  setTimeout delay 500
+
+$ ->
+  for region in ['b', 's']
+    $("span##{region}state select.select2").select2('destroy').addClass 'form-control'

--- a/app/assets/javascripts/address-verification.js.coffee.erb
+++ b/app/assets/javascripts/address-verification.js.coffee.erb
@@ -5,7 +5,7 @@ return if smarty_key == ''
 
 # In theory everything below *should* be replaceable with just:
 #
-#   jQuery.LiveAddress key: smarty_key, enforceVerification: true, autoVerify: false
+#   jQuery.LiveAddress key: smarty_key, enforceVerification: true, autoVerify:
 #
 # But because of a bug in the SmartyStreets plugin we have a lot more code.
 # The country field can be a drop-down but the plugin looks at the "id" not
@@ -51,7 +51,7 @@ $(document).on 'change', country_selector, ->
     service.deactivate validator_id if active
 
 $ ->
-  sreturn unless $.LiveAddress
+  return unless $.LiveAddress
   service = $.LiveAddress
     key: smarty_key, debug: false, enforceVerification: true, autoVerify: false,
     fieldSelector: 'input[type=text], input:not([type]), textarea, select:not([name*="country_id"])'

--- a/app/assets/javascripts/address-verification.js.coffee.erb
+++ b/app/assets/javascripts/address-verification.js.coffee.erb
@@ -57,3 +57,13 @@ $ ->
     fieldSelector: 'input[type=text], input:not([type]), textarea, select:not([name*="country_id"])'
 
   $(country_selector).trigger 'change'
+
+# Allows 3rd party code to manipulate and examine the address verification.
+# Provide any field that is part of the address and it will return the address
+# object.
+@smarty_address_for = (field) ->
+  for address in service.getMappedAddresses()
+    for key, fld of address.getDomFields()
+      return address if field == fld
+
+@smarty_service = -> service

--- a/app/assets/javascripts/address-verification.js.coffee.erb
+++ b/app/assets/javascripts/address-verification.js.coffee.erb
@@ -5,7 +5,7 @@ return if smarty_key == ''
 
 # In theory everything below *should* be replaceable with just:
 #
-#   jQuery.LiveAddress key: smarty_key, enforceVerification: true
+#   jQuery.LiveAddress key: smarty_key, enforceVerification: true, autoVerify: false
 #
 # But because of a bug in the SmartyStreets plugin we have a lot more code.
 # The country field can be a drop-down but the plugin looks at the "id" not
@@ -53,7 +53,7 @@ $(document).on 'change', country_selector, ->
 $ ->
   sreturn unless $.LiveAddress
   service = $.LiveAddress
-    key: smarty_key, debug: false, enforceVerification: true
+    key: smarty_key, debug: false, enforceVerification: true, autoVerify: false,
     fieldSelector: 'input[type=text], input:not([type]), textarea, select:not([name*="country_id"])'
 
   $(country_selector).trigger 'change'

--- a/app/assets/javascripts/address-verification.js.coffee.erb
+++ b/app/assets/javascripts/address-verification.js.coffee.erb
@@ -1,3 +1,5 @@
+#= require address-verification-overrides
+
 $ = jQuery
 
 smarty_key = '<%= ENV['SMARTY_STREETS_WEBSITE_KEY'] %>'

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -49,7 +49,7 @@ Spree::Address.class_eval do
         ), address
         self.address2 = combine %i(secondary_designator secondary_number), address
         self.city = address.components.city_name
-        self.state = Spree::State.find_by abbr: address.components.state_abbreviation
+        self.state = country.states.find_by abbr: address.components.state_abbreviation
         self.zipcode = combine %i(zipcode plus4_code), address, '-'
 
         # Also store the long/lat. It's useful and SmartyStreets provides it

--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -83,6 +83,7 @@ Spree::Address.class_eval do
   private
 
   def automatically_validate_address?
+    return false unless migrated_for_validation?
     return false unless in_united_states?
     return false unless SpreeSmartyStreetsAddressVerification.enabled? self
     return true if address_validation_field_changed?
@@ -90,6 +91,7 @@ Spree::Address.class_eval do
   end
 
   def address_validation_field_changed?
+    return false unless migrated_for_validation?
     return false if new_record? && validated?
     return true if new_record?
     (changed & %w(address1 address2 city zipcode company state_name)).any? ||
@@ -98,6 +100,7 @@ Spree::Address.class_eval do
 
   # Adds an error to the address model if the address is not deliverable
   def check_address
+    return unless migrated_for_validation?
     self.validated = deliverable_address?
     errors[:base] << Spree.t(:invalid_address) unless validated?
   end
@@ -107,6 +110,21 @@ Spree::Address.class_eval do
     components.collect do |method|
       address.components.public_send method
     end.reject(&:blank?) * sep
+  end
+
+  # The `validated` field was added later. If the application:
+  #
+  # * Updates to the version of this plugin with the field
+  # * Hasn't yet run the migration
+  # * Is runnign code that saves addresses (for example an earlier migration)
+  #
+  # Then we get an error. This prevents that error by skipping validation until
+  # the data model is ready.
+  #
+  # OK to remove this down the road once we feel there is not reasonble chance
+  # somebody using the plugin has not run the migration.
+  def migrated_for_validation?
+    respond_to? :validated?
   end
 
 end


### PR DESCRIPTION
There were some corner cases where the address verification wasn't ideal. This cleans those up by:

* Getting rid of the `select2` for the admin state dropdown so that it has a more standardized interface that the address verification can interact with.
* Provides external interface to interact with address verification for more control
* Ensures the verified country is pulled from the US