### PR TITLE
Reload country to ensure value is current.

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -49,7 +49,7 @@ Spree::Address.class_eval do
         ), address
         self.address2 = combine %i(secondary_designator secondary_number), address
         self.city = address.components.city_name
-        self.state = country.states.find_by abbr: address.components.state_abbreviation
+        self.state = country(true).states.find_by abbr: address.components.state_abbreviation
         self.zipcode = combine %i(zipcode plus4_code), address, '-'
 
         # Also store the long/lat. It's useful and SmartyStreets provides it


### PR DESCRIPTION
I'm not sure I completely understand the need for this but it does
seem to be necesary. The following situtation has occurred:

* User's country is not US (either on purpose or due to data error).
* When validating an address they enter a US country.
* The address is valid and get's verified BUT fails to find the
  state during address normalization.

This happens because Smarty Streets returns the state abbreviation
so we need to do a lookup to determine what state record that is.
Historically we didn't scope this to the US resulting in the wrong
record (i.e. a lookup for GA would result in a state in another country
besides the US which has a state whose abbreviation is GA). To fix this
we scoped to the country but were still occasionally getting the issue.

My theory is even though the `country_id` was correctly set to the US,
the already loaded country object was cached to the old country. Forcing
a reload of that relationship fixed this.

What I don't understand is why the user didn't get a different error. At
the start of the verification it checks if it is a US country. When it
does this it uses the same `country` relationship. If that wasn't returning
the US then the verification should not have even taken place.

Despite me not understanding this does fix the problem so leaving it as that
for now.