### PR TITLE
Rewrote most of the JS integration.

### DIFF
--- a/app/assets/javascripts/address-verification-overrides.js.coffee
+++ b/app/assets/javascripts/address-verification-overrides.js.coffee
@@ -1,13 +1,63 @@
 $ = jQuery
 
-old_update_state = window.update_state
-window.update_state = (region, done)->
-  decorated_done = ->
-    $('span#' + region + 'state select.select2').select2 'destroy' if $.fn.select2?
-    done() if done
-  old_update_state region, decorated_done
-
 $(document).on 'ready page:load', ->
+
+  # Must decorate this method in the ready event as Spree doesn't create the
+  # method until the ready event.
+  old_fill_states = Spree.fillStates
+  Spree.fillStates = (data, region) ->
+    country_fld = $ "[id$='_#{if region == 'b' then 'bill' else 'ship'}_address_attributes_country_id']"
+    us_address = $(country_fld).find('option:selected').text().match /united states/i
+
+    state_fld = $ '#' + region + 'state select'
+    smarty_disable state_fld[0], true unless us_address
+    old_fill_states data, region
+
+  # As the page loads tear down the problematic `select2` and make it a standard
+  # control.
   return unless $.fn.select2?
   for region in ['b', 's']
     $("span##{region}state select.select2").select2('destroy').addClass 'form-control'
+
+# If the state is updated we want to decorate two things onto the process:
+#
+# * The select2 that might be activated needs to be de-activated to make it
+#   compatible with the SmartyStreets jQuery plugin. We did this on page load
+#   but as the country is changed Spree will attempt to re-activate select2
+# * We need to de-activate the validator as this means we are switching out
+#   the state which the validator cannot handle.
+old_update_state = window.update_state
+window.update_state = (region, done)->
+  state_fld = $ 'span#' + region + 'state select.select2'
+  smarty_disable state_fld[0], true
+  decorated_done = ->
+    done() if done
+    state_fld.select2 'destroy' if $.fn.select2?
+  old_update_state region, decorated_done
+
+# On the order page the user can disable shipping and instead using the billing
+# for the shipping. When this happens we dont' want to do validation even if
+# a US address. If we re-enable those field we want to notify smarty that it
+# should work again.
+$(document).on 'change', '#order_use_billing', ->
+  address = $('#shipping input[id$="address1"]')[0]
+  return unless address
+  if $('#order_use_billing').is ':checked'
+    smarty_disable address
+  else
+    smarty_enable address
+
+# Ensure initial state is correct regarding smarty and the visibilty of
+# shipping.
+$(document).on 'ready page:load', ->
+  delay = -> $('#order_use_billing').trigger 'change'
+  setTimeout delay, 100
+
+# The smarty street plugin keeps it's own model of the address it validates
+# and does not read the fields. It has change events registered to keep the
+# fields and it's model in sync. When spree updates the billing address fields
+# it updates the value and does not send the change event. This means
+# SmartyStreets does not see the new values entered. This patch sends that
+# event so it Smarty Streets will update it's model.
+$(document).on 'change', '#customer_search', ->
+  $('input[id^="order_bill_address"]').trigger 'change'

--- a/app/assets/javascripts/address-verification.js.coffee.erb
+++ b/app/assets/javascripts/address-verification.js.coffee.erb
@@ -7,7 +7,7 @@ return if smarty_key == ''
 
 # In theory everything below *should* be replaceable with just:
 #
-#   jQuery.LiveAddress key: smarty_key, enforceVerification: true, autoVerify:
+#   jQuery.LiveAddress key: smarty_key, enforceVerification: true, autoVerify: false
 #
 # But because of a bug in the SmartyStreets plugin we have a lot more code.
 # The country field can be a drop-down but the plugin looks at the "id" not
@@ -24,33 +24,17 @@ return if smarty_key == ''
 # This works around the problem.
 #
 # But now we have an additional problem. If the user wants to select a
-# different it will still assume we are in the US and will tell the user that
-# the address is invalid even though it may be a perfectly valid foreign
-# address. To deal with this we enable/disable the address validation
-# depending on if the US is selected.
+# different country, it will still assume we are in the US and will tell the user
+# that the address is invalid even though it may be a perfectly valid foreign
+# address. To deal with this we disable the address validation if foreign.
 #
-# This bug will be fixed when you can go to http://jsfiddle.net/69jv2/629/ and
-# the auto-complete and verification works.
+# If the address started as foreign then switches to US ideally we would like
+# to re-enable the validation but due to another bug in SmartyStreets it doesn't
+# handle the state select list being dynamically updated. In that case we leave
+# it disabled and rely on server-side validation.
 
 service = null
-country_selector = 'select[name*="country_id"]'
-$(document).on 'change', country_selector, ->
-  # Find the validator object related to this country field
-  related_street_field = $('#' + @id.replace(/country_id/, 'address1'))[0]
-  return unless related_street_field
-  address_validator = null;
-  for validator in service.getMappedAddresses()
-    address_validator = validator if validator.getDomFields()['street'] == related_street_field
-  return unless address_validator
-  validator_id = address_validator.id()
-  active = address_validator.active
-
-  # If a US address then activate the validation, otherwise de-activate
-  us_address = $(@).find('option:selected').text().match /united states/i
-  if us_address
-    service.activate validator_id unless active
-  else
-    service.deactivate validator_id if active
+permanently_disabled = {}
 
 $(document).on 'ready page:load', ->
   return unless $.LiveAddress
@@ -58,14 +42,38 @@ $(document).on 'ready page:load', ->
     key: smarty_key, debug: false, enforceVerification: true, autoVerify: false,
     fieldSelector: 'input[type=text], input:not([type]), textarea, select:not([name*="country_id"])'
 
-  $(country_selector).trigger 'change'
+  for country in $ 'select[name*="country_id"]'
+    validator = smarty_validator_for country
+    us_address = $(country).find('option:selected').text().match /united states/i
+    smarty_disable country, true unless us_address
 
-# Allows 3rd party code to manipulate and examine the address verification.
-# Provide any field that is part of the address and it will return the address
-# object.
-@smarty_address_for = (field) ->
-  for address in service.getMappedAddresses()
-    for key, fld of address.getDomFields()
-      return address if field == fld
+# Allows 3rd pary code to inform the plugin that Smarty Streets might need to
+# be activate. It still won't necessarily activate (if a non-US country) but
+# it hands the control to the plugin. Hand any field that is part of the
+# validated address.
+@smarty_enable = (field) ->
+  validator = smarty_validator_for field
+  return unless validator
+  return if validator.active
+  return if permanently_disabled[validator.id()]
+  service.activate validator.id()
 
-@smarty_service = -> service
+# Will explicitly disable the address validation for the given address. Can be
+# any field from the address.
+@smarty_disable = (field, keep_disabled=false) ->
+  validator = smarty_validator_for field
+  return unless validator
+  return unless validator.active
+  permanently_disabled[validator.id()] = true if keep_disabled
+  service.deactivate validator.id()
+
+# Finds the validator associated with the given field
+smarty_validator_for = (field) ->
+  # Country won't be part of the field list so if country was given replace
+  # with primary address
+  field = $('#' + field.id.replace(/country_id/, 'address1'))[0] if field.id.match /country_id/
+
+  # Loop through the validators and find the one which contains the field given
+  for validator in service.getMappedAddresses()
+    for key, fld of validator.getDomFields()
+      return validator if field == fld


### PR DESCRIPTION
There were several corner cases that were not well addressed with the
old code and attempting to tweak it just resulted into a wack-a-mole
situtation.
## Main Integration (address-verification.js.coffee)

The main integration has been simplified to do the following things:
- When the page is loaded the plugin is intiailized
- There is a public method to disable the verification on an address
  given any field from that address.
- There is a public method to re-enable the verification on an address
  given any field from that address.

The `smarty_disable` function can be just for a moment (for example
when shipping is hidden or show) or it can be made permanent if the
optional second argument is true. The reason to permanently disable is
that there are certain situtations where the plugin reaches a state
where it fails to work and there is no way to get it working again.
Tather than it end up in that broken state we actively disable it
proactively.

The primary use case of this permanent disable is when the country
changes. The plugin cannot deal with the state options being swapped
out. When this happens it will always blank out the state causing the
address save to always fail. The primary situtation this would happen
is when the address is Canada and we want to edit it to be US. Switching
to US previously re-enabled the plugin. Now we leave it disabled even
though we should be able to validate the address. Server-side validation
is still in place.

This primary use case is account for in this commit. The main integration
checks for non-US address during load.
## Overrides

To make the plugin work better with Spree there is a bunch of Spree
functionality we tweak. It is as follows:
- If we think the country got changed (due to the states being updated)
  we permanently disable the validation (even if the country became US)
  due to the previously mentioned plugin bug with state options. The
  states are loaded in two different ways (one for the frontend and one
  for the backend). This decorates both state updates.
- The select2 functionality is disabled on the state dropdown. The plugin
  cannot deal well with it. It also hooks into the state updates as Spree
  will try to re-initialize select2.
- If the "Use Billing" option is selected we tweak Spree so that it will
  enable/disable the validation (not permanently) so we don't get validation
  errors on the hidden field which may or may not be valid but it doesn't
  matter.
- When a customer is selected on an order in the backend we send a change
  event as the plugin doesn't actively monitor the fields but instead listens
  for the change event which spree does not send by default.
